### PR TITLE
Simplified exception message template

### DIFF
--- a/src/Dont/Exception/NonDeserialisableObject.php
+++ b/src/Dont/Exception/NonDeserialisableObject.php
@@ -8,13 +8,7 @@ use LogicException;
 
 class NonDeserialisableObject extends LogicException implements ExceptionInterface
 {
-    public static function fromAttemptedDeSerialisation($object) : self
-    {
-        if (! is_object($object)) {
-            throw TypeError::fromNonObject($object);
-        }
-
-        $template = <<<'ERROR'
+    private const ERROR_TEMPLATE = <<<'ERROR'
 The given object %s#%s is not designed to be deserialised, yet deserialisation was attempted.
 
 This error is raised because the author of %s didn't design it to be deserialisable, nor can
@@ -24,10 +18,16 @@ its internal components are deserialisable.
 Please do not use unserialize() to produce %s instances.
 ERROR;
 
+    public static function fromAttemptedDeSerialisation($object) : self
+    {
+        if (! is_object($object)) {
+            throw TypeError::fromNonObject($object);
+        }
+
         $className = get_class($object);
 
         return new self(sprintf(
-            $template,
+            self::ERROR_TEMPLATE,
             $className,
             spl_object_hash($object),
             $className,

--- a/src/Dont/Exception/NonSerialisableObject.php
+++ b/src/Dont/Exception/NonSerialisableObject.php
@@ -8,6 +8,16 @@ use LogicException;
 
 class NonSerialisableObject extends LogicException implements ExceptionInterface
 {
+    private const ERROR_TEMPLATE = <<<'ERROR'
+The given object %s#%s is not designed to be serialised, yet serialisation was attempted.
+
+This error is raised because the author of %s didn't design it to be serialisable, nor can
+guarantee that it will function correctly after serialisation, nor can guarantee that all
+its internal components are serialisable.
+
+Please do not serialise %s instances.
+ERROR;
+
     /**
      * @param object $object
      *
@@ -21,20 +31,10 @@ class NonSerialisableObject extends LogicException implements ExceptionInterface
             throw TypeError::fromNonObject($object);
         }
 
-        $template = <<<'ERROR'
-The given object %s#%s is not designed to be serialised, yet serialisation was attempted.
-
-This error is raised because the author of %s didn't design it to be serialisable, nor can
-guarantee that it will function correctly after serialisation, nor can guarantee that all
-its internal components are serialisable.
-
-Please do not serialise %s instances.
-ERROR;
-
         $className = get_class($object);
 
         return new self(sprintf(
-            $template,
+            self::ERROR_TEMPLATE,
             $className,
             spl_object_hash($object),
             $className,


### PR DESCRIPTION
moved to a private constant to avoid method cluttering

Just making scrutinizer-ci happy, but also happy to play around with constant visibility, finally :-)
