### PR TITLE
Rename unserialize exception

### DIFF
--- a/src/Dont/DontDeserialise.php
+++ b/src/Dont/DontDeserialise.php
@@ -4,17 +4,17 @@ declare(strict_types=1);
 
 namespace Dont;
 
-use Dont\Exception\NonDeserialisableObject;
+use Dont\Exception\ShouldNotUnserializeObject;
 use Dont\Exception\TypeError;
 
 trait DontDeserialise
 {
     /**
-     * @throws NonDeserialisableObject
+     * @throws ShouldNotUnserializeObject
      * @throws TypeError
      */
     final public function __wakeup() : void
     {
-        throw NonDeserialisableObject::fromAttemptedDeSerialisation($this);
+        throw ShouldNotUnserializeObject::fromAttemptedDeSerialisation($this);
     }
 }

--- a/src/Dont/Exception/ShouldNotUnserializeObject.php
+++ b/src/Dont/Exception/ShouldNotUnserializeObject.php
@@ -6,14 +6,14 @@ namespace Dont\Exception;
 
 use LogicException;
 
-class NonDeserialisableObject extends LogicException implements ExceptionInterface
+class ShouldNotUnserializeObject extends LogicException implements ExceptionInterface
 {
     private const ERROR_TEMPLATE = <<<'ERROR'
-The given object %s#%s is not designed to be deserialised, yet deserialisation was attempted.
+The given object %s#%s is not designed to be deserialized, yet deserialization was attempted using
+the `unserialize` funtion.
 
-This error is raised because the author of %s didn't design it to be deserialisable, nor can
-guarantee that it will function correctly after deserialisation, nor can guarantee that all
-its internal components are deserialisable.
+This error is raised because the author of %s didn't design it to be deserialized, nor can guarantee 
+that all its internal components are deserializable. 
 
 Please do not use unserialize() to produce %s instances.
 ERROR;

--- a/src/Dont/Exception/ShouldNotUnserializeObject.php
+++ b/src/Dont/Exception/ShouldNotUnserializeObject.php
@@ -10,7 +10,7 @@ class ShouldNotUnserializeObject extends LogicException implements ExceptionInte
 {
     private const ERROR_TEMPLATE = <<<'ERROR'
 The given object %s#%s is not designed to be deserialized, yet deserialization was attempted using
- the `unserialize` funtion.
+ the `unserialize` function.
 
 This error is raised because the author of %s didn't design it to be deserialized, nor can guarantee 
 that all its internal components are deserializable. 

--- a/src/Dont/Exception/ShouldNotUnserializeObject.php
+++ b/src/Dont/Exception/ShouldNotUnserializeObject.php
@@ -10,7 +10,7 @@ class ShouldNotUnserializeObject extends LogicException implements ExceptionInte
 {
     private const ERROR_TEMPLATE = <<<'ERROR'
 The given object %s#%s is not designed to be deserialized, yet deserialization was attempted using
-the `unserialize` funtion.
+ the `unserialize` funtion.
 
 This error is raised because the author of %s didn't design it to be deserialized, nor can guarantee 
 that all its internal components are deserializable. 

--- a/tests/DontTest/DontDeserialiseTest.php
+++ b/tests/DontTest/DontDeserialiseTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace DontTest;
 
 use Dont\DontDeserialise;
-use Dont\Exception\NonDeserialisableObject;
+use Dont\Exception\ShouldNotUnserializeObject;
 
 /**
  * @covers \Dont\DontDeserialise
@@ -14,7 +14,7 @@ final class DontDeserialiseTest extends \PHPUnit_Framework_TestCase
 {
     public function testWillThrowOnSerialisationAttempt() : void
     {
-        $this->expectException(NonDeserialisableObject::class);
+        $this->expectException(ShouldNotUnserializeObject::class);
 
         unserialize('O:31:"DontTestAsset\NonDeserialisable":0:{}');
     }

--- a/tests/DontTest/Exception/NonDeserialisableObjectTest.php
+++ b/tests/DontTest/Exception/NonDeserialisableObjectTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace DontTest\Exception;
 
@@ -29,12 +29,13 @@ final class NonDeserialisableObjectTest extends \PHPUnit_Framework_TestCase
         self::assertInstanceOf(ExceptionInterface::class, $exception);
 
         $expected = 'The given object ' . get_class($object)
-            . '#' . spl_object_hash($object) . ' is not designed to be deserialised, '
-            . "yet deserialisation was attempted.\n\n"
+            . '#' . spl_object_hash($object) . ' is not designed to be deserialized, '
+            . "yet deserialization was attempted using\n"
+            . " the `unserialize` funtion."
+            . "\n\n"
             . 'This error is raised because the author of ' . get_class($object)
-            . " didn't design it to be deserialisable, nor can\n"
-            . "guarantee that it will function correctly after deserialisation, nor can guarantee that all\n"
-            . "its internal components are deserialisable.\n\n"
+            . " didn't design it to be deserialized, nor can guarantee \n"
+            . "that all its internal components are deserializable. \n\n"
             . 'Please do not use unserialize() to produce ' . get_class($object) . ' instances.';
 
         self::assertSame($expected, $exception->getMessage());

--- a/tests/DontTest/Exception/NonDeserialisableObjectTest.php
+++ b/tests/DontTest/Exception/NonDeserialisableObjectTest.php
@@ -31,7 +31,7 @@ final class NonDeserialisableObjectTest extends \PHPUnit_Framework_TestCase
         $expected = 'The given object ' . get_class($object)
             . '#' . spl_object_hash($object) . ' is not designed to be deserialized, '
             . "yet deserialization was attempted using\n"
-            . " the `unserialize` funtion."
+            . " the `unserialize` function."
             . "\n\n"
             . 'This error is raised because the author of ' . get_class($object)
             . " didn't design it to be deserialized, nor can guarantee \n"

--- a/tests/DontTest/Exception/NonDeserialisableObjectTest.php
+++ b/tests/DontTest/Exception/NonDeserialisableObjectTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace DontTest\Exception;
 
 use Dont\Exception\ExceptionInterface;
-use Dont\Exception\NonDeserialisableObject;
+use Dont\Exception\ShouldNotUnserializeObject;
 use Dont\Exception\TypeError;
 use LogicException;
 use stdClass;
@@ -22,9 +22,9 @@ final class NonDeserialisableObjectTest extends \PHPUnit_Framework_TestCase
      */
     public function testFromAttemptedDeSerialisation($object) : void
     {
-        $exception = NonDeserialisableObject::fromAttemptedDeSerialisation($object);
+        $exception = ShouldNotUnserializeObject::fromAttemptedDeSerialisation($object);
 
-        self::assertInstanceOf(NonDeserialisableObject::class, $exception);
+        self::assertInstanceOf(ShouldNotUnserializeObject::class, $exception);
         self::assertInstanceOf(LogicException::class, $exception);
         self::assertInstanceOf(ExceptionInterface::class, $exception);
 
@@ -60,7 +60,7 @@ final class NonDeserialisableObjectTest extends \PHPUnit_Framework_TestCase
     {
         $this->expectException(TypeError::class);
 
-        NonDeserialisableObject::fromAttemptedDeSerialisation($nonObject);
+        ShouldNotUnserializeObject::fromAttemptedDeSerialisation($nonObject);
     }
 
     /**


### PR DESCRIPTION
I have no idea why I put myself through this, let me know what you think @Ocramius and I will update the `serialize` exception to match once it's merged (if that ever happens).
