### PR TITLE
Updated signatures and return types to be compliant with PHP 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_script:
 
 script:
   - ./vendor/bin/phpunit --disallow-test-output --coverage-clover ./clover.xml
-  - if php -i |grep -qE xdebug; then -d xdebug.mode=coverage ./vendor/bin/infection --min-msi=100 --min-covered-msi=100 --threads=4; fi
+  - if php -i |grep -qE xdebug; then php -d xdebug.mode=coverage ./vendor/bin/infection --min-msi=100 --min-covered-msi=100 --threads=4; fi
 
 after_script:
   - wget https://scrutinizer-ci.com/ocular.phar

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ before_script:
   - composer update
 
 script:
-  - ./vendor/bin/phpunit --disallow-test-output --coverage-clover ./clover.xml
+  - XDEBUG_MODE=coverage ./vendor/bin/phpunit --disallow-test-output --coverage-clover ./clover.xml
   - if php -i |grep -qE xdebug; then php -d xdebug.mode=coverage ./vendor/bin/infection --min-msi=100 --min-covered-msi=100 --threads=4; fi
 
 after_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_script:
 
 script:
   - ./vendor/bin/phpunit --disallow-test-output --coverage-clover ./clover.xml
-  - if php -i |grep -qE xdebug; then ./vendor/bin/infection --min-msi=100 --min-covered-msi=100 --threads=4; fi
+  - if php -i |grep -qE xdebug; then -d xdebug.mode=coverage ./vendor/bin/infection --min-msi=100 --min-covered-msi=100 --threads=4; fi
 
 after_script:
   - wget https://scrutinizer-ci.com/ocular.phar

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_script:
 
 script:
   - XDEBUG_MODE=coverage ./vendor/bin/phpunit --disallow-test-output --coverage-clover ./clover.xml
-  - if php -i |grep -qE xdebug; then php -d xdebug.mode=coverage ./vendor/bin/infection --min-msi=100 --min-covered-msi=100 --threads=4; fi
+  - if php -i |grep -qE xdebug; then XDEBUG_MODE=coverage ./vendor/bin/infection --min-msi=100 --min-covered-msi=100 --threads=4; fi
 
 after_script:
   - wget https://scrutinizer-ci.com/ocular.phar

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,7 @@
 language: php
 
 php:
-  - 7.1
-  - 7.2
-  - 7.3
-  - 7.4
+  - 8.0
 
 before_script:
   - composer update

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "php": "^8.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.5.13",
+        "phpunit/phpunit": "^9.3",
         "infection/infection": "^0.20.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -16,11 +16,11 @@
         }
     ],
     "require": {
-        "php": "^7.1"
+        "php": "^8.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.5 || ^8.0",
-        "infection/infection": "^0.12.0"
+        "phpunit/phpunit": "^8.5.13",
+        "infection/infection": "^0.20.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,30 +1,29 @@
 <?xml version="1.0"?>
-<phpunit
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
-    bootstrap="./vendor/autoload.php"
-    colors="true"
-    convertErrorsToExceptions="true"
-    convertNoticesToExceptions="true"
-    convertWarningsToExceptions="true"
-    beStrictAboutChangesToGlobalState="true"
-    beStrictAboutOutputDuringTests="true"
-    beStrictAboutResourceUsageDuringSmallTests="true"
-    beStrictAboutTestsThatDoNotTestAnything="true"
-    beStrictAboutTodoAnnotatedTests="true"
-    backupStaticAttributes="false"
-    forceCoversAnnotation="true"
-    verbose="true"
-    stopOnFailure="false"
-    processIsolation="false"
-    backupGlobals="false"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         bootstrap="./vendor/autoload.php"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         beStrictAboutChangesToGlobalState="true"
+         beStrictAboutOutputDuringTests="true"
+         beStrictAboutResourceUsageDuringSmallTests="true"
+         beStrictAboutTestsThatDoNotTestAnything="true"
+         beStrictAboutTodoAnnotatedTests="true"
+         backupStaticAttributes="false"
+         forceCoversAnnotation="true"
+         verbose="true"
+         stopOnFailure="false"
+         processIsolation="false"
+         backupGlobals="false"
 >
+    <coverage includeUncoveredFiles="true">
+        <include>
+            <directory suffix=".php">./src</directory>
+        </include>
+    </coverage>
     <testsuite name="roave/don-t tests">
         <directory>./tests/DontTest</directory>
     </testsuite>
-    <filter>
-        <whitelist addUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./src</directory>
-        </whitelist>
-    </filter>
 </phpunit>

--- a/src/Dont/DontDeserialise.php
+++ b/src/Dont/DontDeserialise.php
@@ -22,7 +22,7 @@ trait DontDeserialise
      * @throws NonDeserialisableObject
      * @throws TypeError
      */
-    final public function __unserialize() : array
+    final public function __unserialize(array $data) : void
     {
         throw NonDeserialisableObject::fromAttemptedDeSerialisation($this);
     }

--- a/src/Dont/DontSerialise.php
+++ b/src/Dont/DontSerialise.php
@@ -13,7 +13,7 @@ trait DontSerialise
      * @throws NonSerialisableObject
      * @throws TypeError
      */
-    final public function __sleep() : void
+    final public function __sleep() : array
     {
         throw NonSerialisableObject::fromAttemptedSerialisation($this);
     }
@@ -22,7 +22,7 @@ trait DontSerialise
      * @throws NonSerialisableObject
      * @throws TypeError
      */
-    final public function __serialize() : void
+    final public function __serialize() : array
     {
         throw NonSerialisableObject::fromAttemptedSerialisation($this);
     }

--- a/tests/DontTest/DontDeserialiseTest.php
+++ b/tests/DontTest/DontDeserialiseTest.php
@@ -54,7 +54,7 @@ final class DontDeserialiseTest extends TestCase
     {
         $dont = new NonDeserialisableImplementingSerializable();
         $this->expectException(NonDeserialisableObject::class);
-        $dont->__unserialize();
+        $dont->__unserialize([]);
     }
 
     public function testExceptionFromUnserialize() : void

--- a/tests/DontTest/Exception/ExceptionInterfaceTest.php
+++ b/tests/DontTest/Exception/ExceptionInterfaceTest.php
@@ -15,9 +15,8 @@ final class ExceptionInterfaceTest extends TestCase
 {
     public function testIsThrowable() : void
     {
-        self::assertSame(
-            [Throwable::class],
-            (new \ReflectionClass(ExceptionInterface::class))->getInterfaceNames()
+        self::assertTrue(
+            in_array(Throwable::class, (new \ReflectionClass(ExceptionInterface::class))->getInterfaceNames())
         );
     }
 


### PR DESCRIPTION
This PR should contain all the necessary changes to be compliant with PHP 8. Because it will be BC breaking, I think it should be tagged (if the PR is merged) as 2.0.0. 
Let me know if further changes are needed.