### PR TITLE
Added `DontInstantiate` to the supported traits

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ The package currently provides the following traits:
  * [`Dont\DontCallStatic`](docs/DontCallStatic.md)
  * [`Dont\DontToString`](docs/DontToString.md)
  * [`Dont\JustDont`](docs/JustDont.md)
+ * [`Dont\DontInstantiate`](docs/DontInstantiate.md)
 
 Usage is straightforward:
 

--- a/docs/DontInstantiate.md
+++ b/docs/DontInstantiate.md
@@ -1,0 +1,14 @@
+# DontInstantiate
+
+Prevent object instantiation.
+
+```php
+use Dont\DontInstantiate;
+
+class MyClass
+{
+    use DontInstantiate;
+}
+
+new MyClass(); // will throw Error
+```

--- a/src/Dont/DontInstantiate.php
+++ b/src/Dont/DontInstantiate.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dont;
+
+trait DontInstantiate
+{
+    final private function __construct()
+    {
+    }
+}

--- a/tests/DontTest/DontInstantiateTest.php
+++ b/tests/DontTest/DontInstantiateTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DontTest;
+
+use DontTestAsset\NonInstantiatable;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Dont\DontInstantiate
+ */
+final class DontInstantiateTest extends TestCase
+{
+    public function testWillThrowOnInstantiationAttempt() : void
+    {
+        $this->expectException(\Error::class);
+
+        new NonInstantiatable();
+    }
+}

--- a/tests/DontTestAsset/NonInstantiatable.php
+++ b/tests/DontTestAsset/NonInstantiatable.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DontTestAsset;
+
+use Dont\DontInstantiate;
+
+final class NonInstantiatable
+{
+    use DontInstantiate;
+}


### PR DESCRIPTION
This is useful for static helpers.

There are two ways to implement this:

1. `final private constructor`, which will natively throw an instance of `Error` on instantiation attempt,
2. `final public constructor` with a custom `NonInstantiatableObject` exception like in other traits.

I've decided to implement the first one, since it's a native approach and also PhpStorm automatically removes such classes from `new ...` autocompletion.

I didn't add `DontInstantiate` to `JustDont`, because it obviously breaks BC and also because it makes `JustDont` unusable in most situations.