### PR TITLE
Remove Dont\ToString from Dont\JustDont

### DIFF
--- a/src/Dont/JustDont.php
+++ b/src/Dont/JustDont.php
@@ -13,5 +13,4 @@ trait JustDont
     use DontClone;
     use DontSerialise;
     use DontDeserialise;
-    use DontToString;
 }

--- a/tests/DontTest/DontToStringTest.php
+++ b/tests/DontTest/DontToStringTest.php
@@ -46,7 +46,6 @@ final class DontToStringTest extends TestCase
     {
         return [
             [new NonStringable()],
-            [new DontDoIt()],
         ];
     }
 


### PR DESCRIPTION
Fixes #34
THIS BREAKS BC
The objects which use this trait are not a Stringable anymore.
Refer to #34 for the full rationale.
Thanks @johanrosenson for reminding me of this issue.